### PR TITLE
Fix `afk` team overriding current team

### DIFF
--- a/afk-dim-names/data/afk_team/function/away.mcfunction
+++ b/afk-dim-names/data/afk_team/function/away.mcfunction
@@ -1,1 +1,1 @@
-team join afk @s
+execute if entity @s[team=] run team join afk @s

--- a/afk-dim-names/data/afk_team/function/back.mcfunction
+++ b/afk-dim-names/data/afk_team/function/back.mcfunction
@@ -1,1 +1,1 @@
-team leave @s
+execute if entity @s[team=afk] run team leave @s

--- a/afk-dim-names/default.nix
+++ b/afk-dim-names/default.nix
@@ -1,7 +1,7 @@
 {buildDataPack}:
 buildDataPack {
   name = "afk-dim-names";
-  version = "1.0.1";
+  version = "1.1.0";
 
   src = ./.;
 


### PR DESCRIPTION
See #31

- [x] Test in the minimum supported versions
- [x] Test in the maximum supported versions