### PR TITLE
no-free-deaths: Add option to drop full amount of XP on death

### DIFF
--- a/no-free-deaths/data/no_free_deaths/function/cmd/toggle_curse_of_vanishing.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/cmd/toggle_curse_of_vanishing.mcfunction
@@ -1,5 +1,5 @@
 scoreboard players add .enable_curse_of_vanishing no_free_deaths.settings 1
-execute if score .enable_curse_of_vanishing no_free_deaths.settings matches 1 run tellraw @a {"text": "Items with Curse of Vanishing will now vanish on death"}
+execute if score .enable_curse_of_vanishing no_free_deaths.settings matches 2.. run scoreboard players set .enable_curse_of_vanishing no_free_deaths.settings 0
 
-execute if score .enable_curse_of_vanishing no_free_deaths.settings matches 2 run scoreboard players set .enable_curse_of_vanishing no_free_deaths.settings 0
+execute if score .enable_curse_of_vanishing no_free_deaths.settings matches 1 run tellraw @a {"text": "Items with Curse of Vanishing will now vanish on death"}
 execute if score .enable_curse_of_vanishing no_free_deaths.settings matches 0 run tellraw @a {"text": "Items with Curse of Vanishing will no longer vanish on death"}

--- a/no-free-deaths/data/no_free_deaths/function/cmd/toggle_drop_xp.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/cmd/toggle_drop_xp.mcfunction
@@ -1,5 +1,5 @@
 scoreboard players add .enable_drop_xp no_free_deaths.settings 1
-execute if score .enable_drop_xp no_free_deaths.settings matches 1 run tellraw @a {"text": "Players will now drop XP on death"}
+execute if score .enable_drop_xp no_free_deaths.settings matches 2.. run scoreboard players set .enable_drop_xp no_free_deaths.settings 0
 
-execute if score .enable_drop_xp no_free_deaths.settings matches 2 run scoreboard players set .enable_drop_xp no_free_deaths.settings 0
+execute if score .enable_drop_xp no_free_deaths.settings matches 1 run tellraw @a {"text": "Players will now drop XP on death"}
 execute if score .enable_drop_xp no_free_deaths.settings matches 0 run tellraw @a {"text": "Players will no longer drop XP on death"}

--- a/no-free-deaths/data/no_free_deaths/function/cmd/toggle_drop_xp_in_full.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/cmd/toggle_drop_xp_in_full.mcfunction
@@ -1,0 +1,5 @@
+scoreboard players add .drop_full_xp no_free_deaths.drop_xp.settings 1
+execute if score .drop_full_xp no_free_deaths.drop_xp.settings matches 2.. run scoreboard players set .drop_full_xp no_free_deaths.drop_xp.settings 0
+
+execute if score .drop_full_xp no_free_deaths.drop_xp.settings matches 1 run tellraw @a {"text": "Players will now drop enough XP to fully recover their levels"}
+execute if score .drop_full_xp no_free_deaths.drop_xp.settings matches 0 run tellraw @a {"text": "Players will drop the default amount of XP on death"}

--- a/no-free-deaths/data/no_free_deaths/function/cmd/toggle_respawn_health_penalty.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/cmd/toggle_respawn_health_penalty.mcfunction
@@ -1,5 +1,5 @@
 scoreboard players add .enable_respawn_health_penalty no_free_deaths.settings 1
-execute if score .enable_respawn_health_penalty no_free_deaths.settings matches 1 run tellraw @a {"text": "Players will now respawn with a health penalty"}
+execute if score .enable_respawn_health_penalty no_free_deaths.settings matches 2.. run scoreboard players set .enable_respawn_health_penalty no_free_deaths.settings 0
 
-execute if score .enable_respawn_health_penalty no_free_deaths.settings matches 2 run scoreboard players set .enable_respawn_health_penalty no_free_deaths.settings 0
+execute if score .enable_respawn_health_penalty no_free_deaths.settings matches 1 run tellraw @a {"text": "Players will now respawn with a health penalty"}
 execute if score .enable_respawn_health_penalty no_free_deaths.settings matches 0 run tellraw @a {"text": "Players will no longer respawn with a health penalty"}

--- a/no-free-deaths/data/no_free_deaths/function/cmd/toggle_respawn_hunger_penalty.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/cmd/toggle_respawn_hunger_penalty.mcfunction
@@ -1,5 +1,5 @@
 scoreboard players add .enable_respawn_hunger_penalty no_free_deaths.settings 1
-execute if score .enable_respawn_hunger_penalty no_free_deaths.settings matches 1 run tellraw @a {"text": "Players will now respawn with a hunger penalty"}
+execute if score .enable_respawn_hunger_penalty no_free_deaths.settings matches 2.. run scoreboard players set .enable_respawn_hunger_penalty no_free_deaths.settings 0
 
-execute if score .enable_respawn_hunger_penalty no_free_deaths.settings matches 2 run scoreboard players set .enable_respawn_hunger_penalty no_free_deaths.settings 0
+execute if score .enable_respawn_hunger_penalty no_free_deaths.settings matches 1 run tellraw @a {"text": "Players will now respawn with a hunger penalty"}
 execute if score .enable_respawn_hunger_penalty no_free_deaths.settings matches 0 run tellraw @a {"text": "Players will no longer respawn with a hunger penalty"}

--- a/no-free-deaths/data/no_free_deaths/function/load.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/load.mcfunction
@@ -1,5 +1,7 @@
 scoreboard objectives add no_free_deaths.death_count deathCount
 scoreboard objectives add no_free_deaths.settings dummy
+# The tmp scoreboard is used for calculating values. It MUST only be used within
+# the scope of a single function.
 scoreboard objectives add no_free_deaths.tmp dummy
 
 execute unless score .has_loaded_once no_free_deaths.settings matches 1 run function no_free_deaths:internal/first_load

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/curse_of_vanishing/internal/run_if_supported.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/curse_of_vanishing/internal/run_if_supported.mcfunction
@@ -1,2 +1,0 @@
-execute store result score .data_version no_free_deaths.tmp run data get entity @s DataVersion
-execute if score .data_version no_free_deaths.tmp matches 3819.. run function no_free_deaths:mechanic/curse_of_vanishing/internal/apply

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/curse_of_vanishing/on_death.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/curse_of_vanishing/on_death.mcfunction
@@ -1,1 +1,1 @@
-execute if score .enable_curse_of_vanishing no_free_deaths.settings matches 1 run function no_free_deaths:mechanic/curse_of_vanishing/internal/run_if_supported
+execute if score .enable_curse_of_vanishing no_free_deaths.settings matches 1 run function no_free_deaths:mechanic/curse_of_vanishing/internal/apply

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/apply.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/apply.mcfunction
@@ -1,7 +1,7 @@
 execute as @s store result score @s no_free_deaths.drop_xp.lost_levels run xp query @s levels
+execute store result score @s no_free_deaths.drop_xp.lost_points run xp query @s points
 
-# Players will always lose any points that they've gained when they die.
-# This feels better than keeping them.
+# The points are always reset regardless of the type of XP drop being performed
 xp set @s 0 points
 
 # lost_levels = (player_level * percent) // 100
@@ -9,6 +9,8 @@ xp set @s 0 points
 # As a special case, if the player has 1 level, they will always lose it. Mathematically
 # this doesn't always make sense, but since it's the only level where you could die and
 # respawn with the same number of levels, it doesn't feel right when playing.
+# Since lost_levels is set to the player's XP level, if it is not touched altered,
+# the player will lose that level.
 # The player having 0 levels has already been handled.
 execute if score @s no_free_deaths.drop_xp.lost_levels matches 2.. run scoreboard players operation @s no_free_deaths.drop_xp.lost_levels *= .drop_percentage no_free_deaths.drop_xp.settings
 execute if score @s no_free_deaths.drop_xp.lost_levels matches 2.. run scoreboard players operation @s no_free_deaths.drop_xp.lost_levels /= .100 no_free_deaths.drop_xp.const
@@ -17,9 +19,12 @@ scoreboard players operation @s no_free_deaths.drop_xp.levels_to_remove = @s no_
 execute if score @s no_free_deaths.drop_xp.levels_to_remove matches 1.. as @s run function no_free_deaths:mechanic/drop_xp/internal/remove_xp
 
 # NOTE: With doImmediateRespawn, this would be triggered *after* the player respawns, so if it is enabled,
-# there isn't really a sane way to summon the XP orbs. While player do now store their last death location,
+# there isn't really a sane way to summon the XP orbs. While players do now store their last death location,
 # making the XP spawn there would massively complicate the logic for something that almost nobody uses.
+# However, it's important that this data pack doesn't do something very unexpected in that edge case,
+# such as instantly giving the player that died their XP upon respawn.
 execute store result score .do_immediate_respawn_is_enabled no_free_deaths.tmp run gamerule doImmediateRespawn
 
-scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values = @s no_free_deaths.drop_xp.lost_levels
-execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 1.. if score .do_immediate_respawn_is_enabled no_free_deaths.tmp matches 0 run function no_free_deaths:mechanic/drop_xp/internal/summon_orbs
+execute if score .do_immediate_respawn_is_enabled no_free_deaths.tmp matches 1 run return 0
+execute if score .drop_full_xp no_free_deaths.drop_xp.settings matches 1.. run return run function no_free_deaths:mechanic/drop_xp/internal/full_drop/drop
+function no_free_deaths:mechanic/drop_xp/internal/vanilla_drop/drop

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/first_load.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/first_load.mcfunction
@@ -1,3 +1,4 @@
 scoreboard players set .enable_drop_xp no_free_deaths.settings 1
+scoreboard players set .drop_full_xp no_free_deaths.settings 0
 
 function no_free_deaths:mechanic/drop_xp/api/set_percent_by_difficulty

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/0_to_16.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/0_to_16.mcfunction
@@ -1,0 +1,16 @@
+# (level * level) + (6 * level)
+
+# xp_orb_values = lost_levels
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values = @s no_free_deaths.drop_xp.lost_levels
+
+# xp_orb_values *= xp_orb_values
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values *= @s no_free_deaths.drop_xp.xp_orb_values
+
+# tmp = 6
+scoreboard players operation @s no_free_deaths.tmp = .6 no_free_deaths.drop_xp.const
+
+# tmp *= lost_levels
+scoreboard players operation @s no_free_deaths.tmp *= @s no_free_deaths.drop_xp.lost_levels
+
+# xp_orb_values += tmp
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values += @s no_free_deaths.tmp

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/17_to_31.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/17_to_31.mcfunction
@@ -1,0 +1,18 @@
+# (((25 * (level * level)) − (405 * level)) / 10 + 360
+
+# xp_orb_values = lost_levels
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values = @s no_free_deaths.drop_xp.lost_levels
+# xp_orb_values *= xp_orb_values
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values *= @s no_free_deaths.drop_xp.xp_orb_values
+# xp_orb_values *= 25
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values *= .25 no_free_deaths.drop_xp.const
+# tmp = 405
+scoreboard players operation @s no_free_deaths.tmp = .405 no_free_deaths.drop_xp.const
+# tmp *= lost_levels
+scoreboard players operation @s no_free_deaths.tmp *= @s no_free_deaths.drop_xp.lost_levels
+# xp_orb_values −= tmp
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values -= @s no_free_deaths.tmp
+# xp_orb_values /= 10
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values /= .10 no_free_deaths.drop_xp.const
+# xp_orb_values += 360
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values += .360 no_free_deaths.drop_xp.const

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/32_or_greater.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/32_or_greater.mcfunction
@@ -1,0 +1,18 @@
+# (((45 * (level * level)) − (1625 * level)) / 10) + 2,200
+
+# xp_orb_values = lost_levels
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values = @s no_free_deaths.drop_xp.lost_levels
+# xp_orb_values *= xp_orb_values
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values *= @s no_free_deaths.drop_xp.xp_orb_values
+# xp_orb_values *= 45
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values *= .45 no_free_deaths.drop_xp.const
+# tmp = 1625
+scoreboard players operation @s no_free_deaths.tmp = .1625 no_free_deaths.drop_xp.const
+# tmp *= lost_levels
+scoreboard players operation @s no_free_deaths.tmp *= @s no_free_deaths.drop_xp.lost_levels
+# xp_orb_values −= tmp
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values -= @s no_free_deaths.tmp
+# xp_orb_values /= 10
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values /= .10 no_free_deaths.drop_xp.const
+# xp_orb_values += 2220
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values += .2220 no_free_deaths.drop_xp.const

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/drop.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/drop.mcfunction
@@ -1,0 +1,4 @@
+function no_free_deaths:mechanic/drop_xp/internal/full_drop/set_xp_orb_values
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values += @s no_free_deaths.drop_xp.lost_points
+
+function no_free_deaths:mechanic/drop_xp/internal/summon_orbs

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/set_xp_orb_values.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/full_drop/set_xp_orb_values.mcfunction
@@ -1,0 +1,3 @@
+execute if score @s no_free_deaths.drop_xp.lost_levels matches 32.. run return run function no_free_deaths:mechanic/drop_xp/internal/full_drop/32_or_greater
+execute if score @s no_free_deaths.drop_xp.lost_levels matches 17.. run return run function no_free_deaths:mechanic/drop_xp/internal/full_drop/17_to_31
+function no_free_deaths:mechanic/drop_xp/internal/full_drop/0_to_16

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/1237/a.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/1237/a.mcfunction
@@ -1,0 +1,3 @@
+summon minecraft:experience_orb ~ ~ ~ {Value:1237,Motion:[0.112d,0.092d,-0.0120d]}
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values -= .1237 no_free_deaths.drop_xp.const
+execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 1237.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/1237/b

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/1237/b.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/1237/b.mcfunction
@@ -1,0 +1,3 @@
+summon minecraft:experience_orb ~ ~ ~ {Value:1237,Motion:[-0.072d,0.096d,0.023d]}
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values -= .1237 no_free_deaths.drop_xp.const
+execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 1237.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/1237/a

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/2477/a.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/2477/a.mcfunction
@@ -1,0 +1,3 @@
+summon minecraft:experience_orb ~ ~ ~ {Value:2477,Motion:[-0.034d,0.033d,0.079d]}
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values -= .2477 no_free_deaths.drop_xp.const
+execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 2477.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/2477/b

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/2477/b.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/2477/b.mcfunction
@@ -1,0 +1,3 @@
+summon minecraft:experience_orb ~ ~ ~ {Value:2477,Motion:[0.13d,0.095d,-0.089d]}
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values -= .2477 no_free_deaths.drop_xp.const
+execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 2477.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/2477/a

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/617/a.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/617/a.mcfunction
@@ -1,0 +1,3 @@
+summon minecraft:experience_orb ~ ~ ~ {Value:617,Motion:[0.710d,0.02d,-0.814d]}
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values -= .617 no_free_deaths.drop_xp.const
+execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 617.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/617/b

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/617/b.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orb/617/b.mcfunction
@@ -1,0 +1,3 @@
+summon minecraft:experience_orb ~ ~ ~ {Value:617,Motion:[-0.114d,0.035d,-0.0952d]}
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values -= .617 no_free_deaths.drop_xp.const
+execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 617.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/617/a

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orbs.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/summon_orbs.mcfunction
@@ -1,15 +1,11 @@
-# For some reason, Mojang chose to drop 7 points per level that you lost when you died.
-# That's... not a lot. Maybe a TODO, make this configurable, so you can recover more?
-# It would be a *lot* of effort because you'd need to do some fun calculations to actually
-# figure out the amount of "points" the player had, although since I know Keep Some Inventory 
-# supports fully recovering your XP, they must have an implementation of this.
-scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values *= .7 no_free_deaths.drop_xp.const
-
 # The game splits the total number of points that you lost into various sizes, greedily putting as
 # much as possible into the largest sizes it can. For each size of orb here (replicating the sizes
 # listed here: https://minecraft.wiki/w/Experience#Orb_sizes), the orb is spawned with a precalculated
 # random motion that is supposed to look close enough to vanilla that you won't ever notice it's not
 # *actually* random.
+execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 2477.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/2477/a
+execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 1237.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/1237/a
+execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 617.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/617/a
 execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 307.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/307/a
 execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 149.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/149/a
 execute if score @s no_free_deaths.drop_xp.xp_orb_values matches 73.. run function no_free_deaths:mechanic/drop_xp/internal/summon_orb/73/a

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/vanilla_drop/drop.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/internal/vanilla_drop/drop.mcfunction
@@ -1,0 +1,4 @@
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values = @s no_free_deaths.drop_xp.lost_levels
+scoreboard players operation @s no_free_deaths.drop_xp.xp_orb_values *= .7 no_free_deaths.drop_xp.const
+
+function no_free_deaths:mechanic/drop_xp/internal/summon_orbs

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/load.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/load.mcfunction
@@ -1,13 +1,26 @@
 scoreboard objectives add no_free_deaths.drop_xp.settings dummy
 scoreboard objectives add no_free_deaths.drop_xp.const dummy
-scoreboard objectives add no_free_deaths.drop_xp.lost_levels dummy
+
+# Stores the number of levels that still have to be removed from a player.
+# This value is decremented, and a level is removed, until the value is 0.
 scoreboard objectives add no_free_deaths.drop_xp.levels_to_remove dummy
+
+# The number of levels that the player has lost by dying
+scoreboard objectives add no_free_deaths.drop_xp.lost_levels dummy
+
+# The number of points in the current level that the player has lost by dying
+scoreboard objectives add no_free_deaths.drop_xp.lost_points dummy
+
+# The total value of the XP orbs that will be spawned at the player's location of death
 scoreboard objectives add no_free_deaths.drop_xp.xp_orb_values dummy
 
 # Used as the denominator for the equation in on_death
 scoreboard players set .100 no_free_deaths.drop_xp.const 100
 
 # XP orb values
+scoreboard players set .2477 no_free_deaths.drop_xp.const 2477
+scoreboard players set .1237 no_free_deaths.drop_xp.const 1237
+scoreboard players set .617 no_free_deaths.drop_xp.const 617
 scoreboard players set .307 no_free_deaths.drop_xp.const 307
 scoreboard players set .149 no_free_deaths.drop_xp.const 149
 scoreboard players set .73 no_free_deaths.drop_xp.const 73
@@ -16,6 +29,16 @@ scoreboard players set .17 no_free_deaths.drop_xp.const 17
 scoreboard players set .7 no_free_deaths.drop_xp.const 7
 scoreboard players set .3 no_free_deaths.drop_xp.const 3
 scoreboard players set .1 no_free_deaths.drop_xp.const 1
+
+# Used for calculating the full XP loss amount
+scoreboard players set .6 no_free_deaths.drop_xp.const 6
+scoreboard players set .405 no_free_deaths.drop_xp.const 405
+scoreboard players set .25 no_free_deaths.drop_xp.const 25
+scoreboard players set .360 no_free_deaths.drop_xp.const 360
+scoreboard players set .10 no_free_deaths.drop_xp.const 10
+scoreboard players set .45 no_free_deaths.drop_xp.const 45
+scoreboard players set .2220 no_free_deaths.drop_xp.const 2220
+scoreboard players set .1625 no_free_deaths.drop_xp.const 1625
 
 # If the mechanic is neither enabled nor disabled, this must be its first load
 execute unless score .enable_drop_xp no_free_deaths.settings matches 0.. run function no_free_deaths:mechanic/drop_xp/internal/first_load

--- a/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/on_death.mcfunction
+++ b/no-free-deaths/data/no_free_deaths/function/mechanic/drop_xp/on_death.mcfunction
@@ -4,4 +4,8 @@
 execute if score .drop_percentage no_free_deaths.drop_xp.settings matches 101.. run scoreboard players set .drop_percentage no_free_deaths.drop_xp.settings 100
 execute if score .drop_percentage no_free_deaths.drop_xp.settings matches ..-1 run scoreboard players set .drop_percentage no_free_deaths.drop_xp.settings 0
 
+# If the player has configured dropping the full amount of XP, the drop percentage will always be 100%.
+# The way XP works in this game is annoying, so this is the only way to guarantee a reasonable behaviour.
+execute unless score .drop_percentage no_free_deaths.drop_xp.settings matches 100 if score .drop_full_xp no_free_deaths.drop_xp.settings matches 1 run scoreboard players set .drop_percentage no_free_deaths.settings 100
+
 execute unless score .drop_percentage no_free_deaths.drop_xp.settings matches 0 as @s at @s run function no_free_deaths:mechanic/drop_xp/internal/apply

--- a/no-free-deaths/default.nix
+++ b/no-free-deaths/default.nix
@@ -1,19 +1,9 @@
 { buildDataPack }:
 buildDataPack {
   name = "no-free-deaths";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = ./.;
-
-  preprocess = ''
-    shopt -s nullglob globstar
-    pushd data
-    for dir in **/function **/advancement; do
-      cp -r $dir ''${dir}s
-    done
-    popd
-    touch **
-  '';
 
   include = [
     "LICENSE"

--- a/no-free-deaths/pack.mcmeta
+++ b/no-free-deaths/pack.mcmeta
@@ -1,7 +1,7 @@
 {
   "pack": {
-    "pack_format": 8,
+    "pack_format": 41,
     "description": "No more free deaths. It's keepInventory with consequences (for those that want them).",
-    "supported_formats": [8, 61]
+    "supported_formats": [41, 61]
   }
 }


### PR DESCRIPTION
Previously, this data pack always followed the vanilla behaviour, which was to calculate the number of levels lost, multiply that by 7, and drop that amount of XP. I personally actually really like this, and want to keep it as the default. However, it makes sense to support players recovering the full amount of their XP. Because of the way it's calculated, it doesn't support dropping a percentage of the player's levels.

This can be toggled by admins using a new function:
```
/function no_free_deaths:cmd/toggle_drop_xp_in_full
```